### PR TITLE
[ES] Add ES

### DIFF
--- a/overlays/elastic/Makefile
+++ b/overlays/elastic/Makefile
@@ -1,0 +1,28 @@
+
+
+ELASTIC_VERSION := v8.5.1
+
+helm:
+	helm repo add elastic https://helm.elastic.co
+	helm repo update elastic
+
+
+elasticSearch-deployment:
+	helm template elasticsearch elastic/elasticsearch --version=${ELASTIC_VERSION} --values=elasticsearch/values-elasticsearch.yaml > elasticsearch/helm-elasticsearch.yaml
+
+elasticsearch: helm elasticSearch-deployment
+
+run-dump: 
+	kubectl kustomize .
+
+dump:  elasticsearch run-dump
+
+run-apply:  
+	kubectl apply -k .
+
+apply:  elasticsearch run-apply
+
+run-destroy:
+	kubectl delete -k .
+
+destroy:  elasticsearch run-destroy

--- a/overlays/elastic/elasticsearch/helm-elasticsearch.yaml
+++ b/overlays/elastic/elasticsearch/helm-elasticsearch.yaml
@@ -1,0 +1,337 @@
+# Source: elasticsearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "elasticsearch-master-pdb"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: "elasticsearch-master"
+---
+# Source: elasticsearch/templates/secret-cert.yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: elasticsearch-master-certs
+  labels:
+    app: elasticsearch-master
+    chart: "elasticsearch"
+    heritage: Helm
+    release: elasticsearch
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoRENDQW15Z0F3SUJBZ0lSQUoycjRpYXJXZ0c1eVBVUnZmMlVPSW93RFFZSktvWklodmNOQVFFTEJRQXcKR3pFWk1CY0dBMVVFQXhNUVpXeGhjM1JwWTNObFlYSmphQzFqWVRBZUZ3MHlNekV5TVRJeE5EQXlOVFphRncweQpOREV5TVRFeE5EQXlOVFphTUI4eEhUQWJCZ05WQkFNVEZHVnNZWE4wYVdOelpXRnlZMmd0YldGemRHVnlNSUlCCklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzKzhhK2ZZTzRLZ2pJd01OUmNhVHFCWngKNlNiTUh0YTVlYXlFeWFDTnUwY2xrSnZFdG1VVlZ5VXVGSlFQOG9yczhTNWVSbFV6anJkQ1ArR01EOGFQRmNLSQpuZ2ZBcDMvYkVpTzNNWXMrK2RLYTJyd3dpTGFrZDNicU9EMnVrSC85UGJ2ZGJ1endiakFDSjdyUGZDamFwOGxHCk9rcFR5UThyZHhYeDhzVnpYeno5amFMM2lJL0puOXl3cVh2cnJNOHFob3NDOExWejJUd0tsaFZnaWVKMFNHdlAKNmw0b2lTdFk4UVRYcEdxQmk0cktZZ2ZVTDJSUmh1Q2NWTXAxczJZVWh4RjF0MHd4Q25qYWtTcFNyZTlLbjRiVQo5NkJ6ZzMvVjZMYjFleW85MEgzU1BCeEVEVUltNGxFYm1EWWFuRzJzMEN5UjJPN0JodHFwZVhxSVF2aTRBUUlECkFRQUJvNEcrTUlHN01BNEdBMVVkRHdFQi93UUVBd0lGb0RBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFRWUkKS3dZQkJRVUhBd0l3REFZRFZSMFRBUUgvQkFJd0FEQWZCZ05WSFNNRUdEQVdnQlMzVGhuME8zOWw3YVMxR2hLTgozVEFWK010VU5EQmJCZ05WSFJFRVZEQlNnaFJsYkdGemRHbGpjMlZoY21Ob0xXMWhjM1JsY29JYVpXeGhjM1JwClkzTmxZWEpqYUMxdFlYTjBaWEl1Y25WamFXK0NIbVZzWVhOMGFXTnpaV0Z5WTJndGJXRnpkR1Z5TG5KMVkybHYKTG5OMll6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUF4ejkxL2pPeVRkMGtOUDRsKytOVThrTjIyaWZVSDQzSQoydkpEZFNHQVlUQktISDE4M0pnenJQSUs0RnRzUzRnQkxSbVRsUDcrNmJ3aFJTVlFQRXljbG9zT1Zhd2FDbG15ClRkbEdmVVBaa0xSSWNvTmM1c3lNV0d6OEtXUFEvd1dpekJZRU1yL0swMDk4TmpqTHZRY3dhQTc2d0wyVVF3ZGIKcVUxaGNXU01SS0NrYkpkTkhuUHZOc3c3VmNLdlJod0VCWU8yTklUZlJZSm5DU0owVVczQnlBZFVNZXNQNytUWgp2MFVSMlAwbzlLMXJPNHl0Mktxd0Y1K0ZQMlBvWE5QaFA4OVdEbXVEUFM1WnpnUkJHaGIwRVBzL1dxUWxsYmE5CjRqSW5IQ21iaGZsUFE5WUNLOUx0dVFsazdFWmtUUDNXdndreUpXeWZrbGpxaGtTbzdsUHhIdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBMys4YStmWU80S2dqSXdNTlJjYVRxQlp4NlNiTUh0YTVlYXlFeWFDTnUwY2xrSnZFCnRtVVZWeVV1RkpRUDhvcnM4UzVlUmxVempyZENQK0dNRDhhUEZjS0luZ2ZBcDMvYkVpTzNNWXMrK2RLYTJyd3cKaUxha2QzYnFPRDJ1a0gvOVBidmRidXp3YmpBQ0o3clBmQ2phcDhsR09rcFR5UThyZHhYeDhzVnpYeno5amFMMwppSS9Kbjl5d3FYdnJyTThxaG9zQzhMVnoyVHdLbGhWZ2llSjBTR3ZQNmw0b2lTdFk4UVRYcEdxQmk0cktZZ2ZVCkwyUlJodUNjVk1wMXMyWVVoeEYxdDB3eENuamFrU3BTcmU5S240YlU5NkJ6ZzMvVjZMYjFleW85MEgzU1BCeEUKRFVJbTRsRWJtRFlhbkcyczBDeVIyTzdCaHRxcGVYcUlRdmk0QVFJREFRQUJBb0lCQUNud2JBcjRiRnppNElIRQpKbzQwM0o2VVpZMFcrUStsZzJNb1RrNDh4WTZYaW8rRXZOaTBJY1VLYjVEbkVmMkl5MHQ0TmF2U2RTOTdYdXI3CjRQRnJiSXpVdkNWc3FrWTBpZURoMDROeDRyK0RGQUYzVVZlcGJTLzZrMjhwRGpKOTVmM1QyMnJVOFVxUnJ6V2wKcFFwSjFIbXNGbjBBUXFUYk5IYS9JMnNtVTY4NE1VZzAxMmRybWI5dVdXTkFwWkxkTE1lUWtWd2QybHhvQUpvcQphMGJQNGNHV0dIWnFwaG45dS9KdXQ0K2phTXZqUUxSREQzMkltekhSL2NwRVROYXBTNlNiVzZZVkg4dEt4MHZJCnVmRXVYNzQ0Wjg1MXRHbWIxN0hLYzBkSjNtTDlnbDArUnVVNDF1TUZCT1EvbHJvUXNSaEFiKytUamlEKzRCR2YKUGxqZGJnRUNnWUVBOUlyb3JWY1J4RTFHK3AzeTU2OG1qRU01dFFya3ovUGZMTkc3YnZhWWYzVTk4NzJmWTRLWgpIYTFGRzl5Z2FFNjJZaVEyQ2ViWjdiSUcvcEpYUUFZbzhXbWRKbk1oOWdheFo1YVJNRVVESFJieTBpMVpreUoxCldkbWpMNlROQTJMNTVXN3VidXVncnJoTGxyRmZYd1FaY2RBZVJuTW9VejQyajc4d0s3RENPZkVDZ1lFQTZtMEQKVER0YmlsNk9CTVNlMEp2eXl5SExBY3YzOTN4Y1RZNjZNSjhjanpoaGdFODRPd1dTMFJrNmRQRTdyV0VldXNNawptUmNHR1Z6YTlaQUVCSzhucGVRZVAzZmYyMUJRRFFTR2s4cDhSL2ZJL01Qbm4vSG90ZXlUbXNDR0VyMWJ4SWdXClF0bWpPQmdXSDQwdld1aWtGc1hLZHB6NVBxMG11aVp0a2F2Snp4RUNnWUVBMzJ0YUVhU1BFdTRYZnpsM2g3MDYKVnNQRW9XZUdqWWVkeXZFRGNlblNnZ0MzelV6ZHBxalhBNG9lcmNud3M5dldQZXdmZ3dScTd3UEw2Q0lEblBjRAp5U3hZNjV3YzF3NWVYdW50VkZCNCs4YlBxcjdNSytVN21nK0JUREloTElydERYVkFXZzdsQ3p4TnN5dnltbmpBClZuOXlhYU1rb0lraWlFcUExQ24yQ2NFQ2dZRUFreVBQY1JiRXMwbjhIQlFKbHVoN2NYS0ppRnd0RFFMYXNMZUkKT0NKMmU1S282QzlSSFFLM2oxVWxjdWREVE9UcnM4L3VkY1NVeUhDVzRwRDlaSzlIMUlFbFZ6TDNxQ0YxeldYcwp6bkRHcHlsbzF2Wmp1T25PNWZsVEFFd2RHMEFOaklMYWJpVktwRmZCOHhYY0JsU0ZRZUh0M1p0VGVqcVdWenJ0CmhRUnRpL0VDZ1lFQXpyNFpnMVJVTDJJK3lhMnVVTTZwNFJYRzNWbXM0TVY1cmIvUk0zWXdqMzMvZHZBNzRaWTIKZFJFMzVXNW44TUZCZTBjQUpmejJKN2YvUzFVOWc0Z0RQSUpGMWNINnFFUXJuL2xvODVYRmpUUlFpTTUzUnd0bwpXRmJlNGZ0RGVUOXlDajlzcCs1WXBCaDNacW8xUElhbnlTUHN0eVRsNnlTTVI4VmlmQVpEWUNNPQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJVENDQWdtZ0F3SUJBZ0lRREx2eFNTcU9sN0NsMmpST3lWSTlhekFOQmdrcWhraUc5dzBCQVFzRkFEQWIKTVJrd0Z3WURWUVFERXhCbGJHRnpkR2xqYzJWaGNtTm9MV05oTUI0WERUSXpNVEl4TWpFME1ESTFObG9YRFRJMApNVEl4TVRFME1ESTFObG93R3pFWk1CY0dBMVVFQXhNUVpXeGhjM1JwWTNObFlYSmphQzFqWVRDQ0FTSXdEUVlKCktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU5yTFZSRitTZjUvUjdlRmhVNDlLNG1OSThDVS85Uy8Kd2s5U1A3bDB1R090VjdodDhjMUE0VmVOTGFYL1JISWo5VDRJdnRoSFp1QW1jWG51cEtVVFBkRnc4M1U0aG1IWgpTMVBQK3BQcDM5S0xmZENVT2VLNEdaTEM5UzB6RndXNThBZmQyYWhUQ2RVcXppWDJSMUNKY0ozeXNSYkxXSmpYCnRGZmZQeEFVZFZtL24rNktIdmpaU0N4RkZVT0d6YWkwTEtqUGt3dFlmNmszSWJpdlRRR1lJKzdtMjlSTEwvNTgKWUtVaWNuNGtxMGpzSkRtUk1sdUFhbHJYYVp5ajN4eENkUU56eXFTQzdvNCtibnVPaUwrdHhTRTc5d0xqaE9CRwpqbkdUZVdheGNXNWtyY1BBRHExQXU1dE8rK25mL1U4SHZnejJ3dnV5N3dmWlk3V29ReDdJT2VzQ0F3RUFBYU5oCk1GOHdEZ1lEVlIwUEFRSC9CQVFEQWdLa01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0QKQWpBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJTM1RobjBPMzlsN2FTMUdoS04zVEFWK010VQpOREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBRzNKb0N3V2lNc2czMU9xUDhNbmtZUFROL0FUa3QydkRwOHUxCndqemRETld4RnZkc0dnOEFlSmNzdWRKdG5FRTZqbVpKdFpKbGV3WUt5N2FFSy8wakxpU0JqTFZaNWJZYmh1WC8KMloxbFR5SEU0N2NuMFp6Unk2SmtJQTkvTGp3TDQyaktnMStCMVNsanlrK1V2a1ZJZHFBSi9ZeUpTdVRCd2VxZQplVm95eElCWVhnTEdNM2RwT2pKZUI5RW9PMFVGZ0ZmNEJXRHkyOWY5ZmRhL0JlQ2NDR3NVZCsvbndoL3F4cjViCndmckFVVzhVQ1NXdW55YW4wQ29sYWl6ZGhuc0sxaHlBbXN0ZDZMZDNGb0xvNmNiMDVHTXR0UmUzRzY1aWMrVEYKNCtBMVgrR1ZwdEE2NlJrZm9IaUQ2RENyL1ZrTUZoZy9yRDAxVGRSeFBZZjlQMkRmcmc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+# Source: elasticsearch/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elasticsearch-master-credentials
+  labels:
+    heritage: "Helm"
+    release: "elasticsearch"
+    chart: "elasticsearch"
+    app: "elasticsearch-master"
+type: Opaque
+data:
+  username: ZWxhc3RpYw==
+  password: "RHJUbUh5dkJ5SUVyaWpOUA=="
+---
+# Source: elasticsearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: elasticsearch-master
+  labels:
+    heritage: "Helm"
+    release: "elasticsearch"
+    chart: "elasticsearch"
+    app: "elasticsearch-master"
+  annotations: {}
+spec:
+  type: ClusterIP
+  selector:
+    release: "elasticsearch"
+    chart: "elasticsearch"
+    app: "elasticsearch-master"
+  publishNotReadyAddresses: false
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+---
+# Source: elasticsearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: elasticsearch-master-headless
+  labels:
+    heritage: "Helm"
+    release: "elasticsearch"
+    chart: "elasticsearch"
+    app: "elasticsearch-master"
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like elasticsearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app: "elasticsearch-master"
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+---
+# Source: elasticsearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch-master
+  labels:
+    heritage: "Helm"
+    release: "elasticsearch"
+    chart: "elasticsearch"
+    app: "elasticsearch-master"
+  annotations:
+    esMajorVersion: "8"
+spec:
+  serviceName: elasticsearch-master-headless
+  selector:
+    matchLabels:
+      app: "elasticsearch-master"
+  replicas: 3
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-master
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 30Gi
+  template:
+    metadata:
+      name: "elasticsearch-master"
+      labels:
+        release: "elasticsearch"
+        chart: "elasticsearch"
+        app: "elasticsearch-master"
+      annotations:
+
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - "elasticsearch-master"
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: elasticsearch-certs
+        secret:
+          secretName: elasticsearch-master-certs
+      enableServiceLinks: true
+      initContainers:
+      - name: configure-sysctl
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        image: "docker.elastic.co/elasticsearch/elasticsearch:8.5.1"
+        imagePullPolicy: "IfNotPresent"
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        resources: {}
+
+      containers:
+      - name: "elasticsearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+        image: "docker.elastic.co/elasticsearch/elasticsearch:8.5.1"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+
+              # Exit if ELASTIC_PASSWORD in unset
+              if [ -z "${ELASTIC_PASSWORD}" ]; then
+                echo "ELASTIC_PASSWORD variable is missing, exiting"
+                exit 1
+              fi
+
+              # If the node is starting up wait for the cluster to be ready (request params: "wait_for_status=green&timeout=1s" )
+              # Once it has started only check that the node itself is responding
+              START_FILE=/tmp/.es_start_file
+
+              # Disable nss cache to avoid filling dentry cache when calling curl
+              # This is required with Elasticsearch Docker using nss < 3.52
+              export NSS_SDB_USE_CACHE=no
+
+              http () {
+                local path="${1}"
+                local args="${2}"
+                set -- -XGET -s
+
+                if [ "$args" != "" ]; then
+                  set -- "$@" $args
+                fi
+
+                set -- "$@" -u "elastic:${ELASTIC_PASSWORD}"
+
+                curl --output /dev/null -k "$@" "https://127.0.0.1:9200${path}"
+              }
+
+              if [ -f "${START_FILE}" ]; then
+                echo 'Elasticsearch is already running, lets check the node is healthy'
+                HTTP_CODE=$(http "/" "-w %{http_code}")
+                RC=$?
+                if [[ ${RC} -ne 0 ]]; then
+                  echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} https://127.0.0.1:9200/ failed with RC ${RC}"
+                  exit ${RC}
+                fi
+                # ready if HTTP code 200, 503 is tolerable if ES version is 6.x
+                if [[ ${HTTP_CODE} == "200" ]]; then
+                  exit 0
+                elif [[ ${HTTP_CODE} == "503" && "8" == "6" ]]; then
+                  exit 0
+                else
+                  echo "curl --output /dev/null -k -XGET -s -w '%{http_code}' \${BASIC_AUTH} https://127.0.0.1:9200/ failed with HTTP code ${HTTP_CODE}"
+                  exit 1
+                fi
+
+              else
+                echo 'Waiting for elasticsearch cluster to become ready (request params: "wait_for_status=green&timeout=1s" )'
+                if http "/_cluster/health?wait_for_status=green&timeout=1s" "--fail" ; then
+                  touch ${START_FILE}
+                  exit 0
+                else
+                  echo 'Cluster is not yet ready (request params: "wait_for_status=green&timeout=1s" )'
+                  exit 1
+                fi
+              fi
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+          requests:
+            cpu: 1000m
+            memory: 2Gi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: cluster.initial_master_nodes
+          value: "elasticsearch-master-0,elasticsearch-master-1,elasticsearch-master-2,"
+        - name: node.roles
+          value: "master,data,data_content,data_hot,data_warm,data_cold,ingest,remote_cluster_client,transform,"
+        - name: discovery.seed_hosts
+          value: "elasticsearch-master-headless"
+        - name: cluster.name
+          value: "elasticsearch"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: ELASTIC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: elasticsearch-master-credentials
+              key: password
+        - name: xpack.security.enabled
+          value: "true"
+        - name: xpack.security.transport.ssl.enabled
+          value: "true"
+        - name: xpack.security.http.ssl.enabled
+          value: "true"
+        - name: xpack.security.transport.ssl.verification_mode
+          value: "certificate"
+        - name: xpack.security.transport.ssl.key
+          value: "/usr/share/elasticsearch/config/certs/tls.key"
+        - name: xpack.security.transport.ssl.certificate
+          value: "/usr/share/elasticsearch/config/certs/tls.crt"
+        - name: xpack.security.transport.ssl.certificate_authorities
+          value: "/usr/share/elasticsearch/config/certs/ca.crt"
+        - name: xpack.security.http.ssl.key
+          value: "/usr/share/elasticsearch/config/certs/tls.key"
+        - name: xpack.security.http.ssl.certificate
+          value: "/usr/share/elasticsearch/config/certs/tls.crt"
+        - name: xpack.security.http.ssl.certificate_authorities
+          value: "/usr/share/elasticsearch/config/certs/ca.crt"
+        volumeMounts:
+        - name: "elasticsearch-master"
+          mountPath: /usr/share/elasticsearch/data
+        - name: elasticsearch-certs
+          mountPath: /usr/share/elasticsearch/config/certs
+          readOnly: true
+---
+# Source: elasticsearch/templates/test/test-elasticsearch-health.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "elasticsearch-sewbt-test"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+  containers:
+  - name: "elasticsearch-ifddm-test"
+    env:
+    - name: ELASTIC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: elasticsearch-master-credentials
+          key: password
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.5.1"
+    imagePullPolicy: "IfNotPresent"
+    command:
+    - "sh"
+    - "-c"
+    - |
+      #!/usr/bin/env bash -e
+      curl -XGET --fail --cacert /usr/share/elasticsearch/config/certs/tls.crt -u "elastic:${ELASTIC_PASSWORD}" https://'elasticsearch-master:9200/_cluster/health?wait_for_status=green&timeout=1s'
+    volumeMounts:
+    - name: elasticsearch-certs
+      mountPath: /usr/share/elasticsearch/config/certs
+      readOnly: true
+  restartPolicy: Never
+  volumes:
+  - name: elasticsearch-certs
+    secret:
+      secretName: elasticsearch-master-certs

--- a/overlays/elastic/elasticsearch/kustomization.yaml
+++ b/overlays/elastic/elasticsearch/kustomization.yaml
@@ -1,0 +1,9 @@
+namespace: elastic-system
+
+resources:
+- helm-elasticsearch.yaml
+
+
+patchesStrategicMerge: []
+
+secretGenerator: []

--- a/overlays/elastic/elasticsearch/values-elasticsearch.yaml
+++ b/overlays/elastic/elasticsearch/values-elasticsearch.yaml
@@ -1,0 +1,355 @@
+clusterName: "elasticsearch"
+nodeGroup: "master"
+
+# The service that non master groups will try to connect to when joining the cluster
+# This should be set to clusterName + "-" + nodeGroup for your master group
+masterService: "elasticsearch-master"
+
+# Elasticsearch roles that will be applied to this nodeGroup
+# These will be set as environment variables. E.g. node.roles=master
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#node-roles
+roles:
+- master
+- data
+- data_content
+- data_hot
+- data_warm
+- data_cold
+- ingest
+- remote_cluster_client
+- transform
+# - ml
+
+replicas: 3
+minimumMasterNodes: 2
+
+esMajorVersion: "8"
+
+# Allows you to add any config files in /usr/share/elasticsearch/config/
+# such as elasticsearch.yml and log4j2.properties
+esConfig: {}
+#  elasticsearch.yml: |
+#    key:
+#      nestedkey: value
+#  log4j2.properties: |
+#    key = value
+
+createCert: true
+
+esJvmOptions: {}
+#  processors.options: |
+#    -XX:ActiveProcessorCount=3
+
+# Extra environment variables to append to this nodeGroup
+# This will be appended to the current 'env:' key. You can use any of the kubernetes env
+# syntax here
+extraEnvs: []
+#  - name: MY_ENVIRONMENT_VAR
+#    value: the_value_goes_here
+
+# Allows you to load environment variables from kubernetes secret or config map
+envFrom: []
+# - secretRef:
+#     name: env-secret
+# - configMapRef:
+#     name: config-map
+
+# Disable it to use your own elastic-credential Secret.
+secret:
+  enabled: true
+  password: "" # generated randomly if not defined
+
+# A list of secrets and their paths to mount inside the pod
+# This is useful for mounting certificates for security and for mounting
+# the X-Pack license
+secretMounts: []
+#  - name: elastic-certificates
+#    secretName: elastic-certificates
+#    path: /usr/share/elasticsearch/config/certs
+#    defaultMode: 0755
+
+hostAliases: []
+#- ip: "127.0.0.1"
+#  hostnames:
+#  - "foo.local"
+#  - "bar.local"
+
+image: "docker.elastic.co/elasticsearch/elasticsearch"
+imageTag: "8.5.1"
+imagePullPolicy: "IfNotPresent"
+
+podAnnotations: {}
+# iam.amazonaws.com/role: es-cluster
+
+# additionals labels
+labels: {}
+
+esJavaOpts: "" # example: "-Xmx1g -Xms1g"
+
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+
+initResources: {}
+# limits:
+#   cpu: "25m"
+#   # memory: "128Mi"
+# requests:
+#   cpu: "25m"
+#   memory: "128Mi"
+
+networkHost: "0.0.0.0"
+
+volumeClaimTemplate:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 30Gi
+
+rbac:
+  create: false
+  serviceAccountAnnotations: {}
+  serviceAccountName: ""
+  automountToken: true
+
+podSecurityPolicy:
+  create: false
+  name: ""
+  spec:
+    privileged: true
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+    - secret
+    - configMap
+    - persistentVolumeClaim
+    - emptyDir
+
+persistence:
+  enabled: true
+  labels:
+    # Add default labels for the volumeClaimTemplate of the StatefulSet
+    enabled: false
+  annotations: {}
+
+extraVolumes: []
+# - name: extras
+#   emptyDir: {}
+
+extraVolumeMounts: []
+# - name: extras
+#   mountPath: /usr/share/extras
+#   readOnly: true
+
+extraContainers: []
+# - name: do-something
+#   image: busybox
+#   command: ['do', 'something']
+
+extraInitContainers: []
+# - name: do-something
+#   image: busybox
+#   command: ['do', 'something']
+
+# This is the PriorityClass settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
+# By default this will make sure two pods don't end up on the same node
+# Changing this to a region would allow you to spread pods across regions
+antiAffinityTopologyKey: "kubernetes.io/hostname"
+
+# Hard means that by default pods will only be scheduled if there are enough nodes for them
+# and that they will never end up on the same node. Setting this to soft will do this "best effort"
+antiAffinity: "hard"
+
+# This is the node affinity settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+nodeAffinity: {}
+
+# The default is to deploy all pods serially. By setting this to parallel all pods are started at
+# the same time when bootstrapping the cluster
+podManagementPolicy: "Parallel"
+
+# The environment variables injected by service links are not used, but can lead to slow Elasticsearch boot times when
+# there are many services in the current namespace.
+# If you experience slow pod startups you probably want to set this to `false`.
+enableServiceLinks: true
+
+protocol: https
+httpPort: 9200
+transportPort: 9300
+
+service:
+  enabled: true
+  labels: {}
+  labelsHeadless: {}
+  type: ClusterIP
+  # Consider that all endpoints are considered "ready" even if the Pods themselves are not
+  # https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+  publishNotReadyAddresses: false
+  nodePort: ""
+  annotations: {}
+  httpPortName: http
+  transportPortName: transport
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  externalTrafficPolicy: ""
+
+updateStrategy: RollingUpdate
+
+# This is the max unavailable setting for the pod disruption budget
+# The default value of 1 will make sure that kubernetes won't allow more than 1
+# of your pods to be unavailable during maintenance
+maxUnavailable: 1
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  # readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# How long to wait for elasticsearch to stop gracefully
+terminationGracePeriod: 120
+
+sysctlVmMaxMapCount: 262144
+
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 3
+  timeoutSeconds: 5
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#request-params wait_for_status
+clusterHealthCheckParams: "wait_for_status=green&timeout=1s"
+
+## Use an alternate scheduler.
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+
+imagePullSecrets: []
+nodeSelector: {}
+tolerations: []
+
+# Enabling this will publicly expose your Elasticsearch instance.
+# Only enable this if you have security enabled on your cluster
+ingress:
+  enabled: false
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  className: "nginx"
+  pathtype: ImplementationSpecific
+  hosts:
+  - host: chart-example.local
+    paths:
+    - path: /
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+nameOverride: ""
+fullnameOverride: ""
+healthNameOverride: ""
+
+lifecycle: {}
+# preStop:
+#   exec:
+#     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+# postStart:
+#   exec:
+#     command:
+#       - bash
+#       - -c
+#       - |
+#         #!/bin/bash
+#         # Add a template to adjust number of shards/replicas
+#         TEMPLATE_NAME=my_template
+#         INDEX_PATTERN="logstash-*"
+#         SHARD_COUNT=8
+#         REPLICA_COUNT=1
+#         ES_URL=http://localhost:9200
+#         while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
+#         curl -XPUT "$ES_URL/_template/$TEMPLATE_NAME" -H 'Content-Type: application/json' -d'{"index_patterns":['\""$INDEX_PATTERN"\"'],"settings":{"number_of_shards":'$SHARD_COUNT',"number_of_replicas":'$REPLICA_COUNT'}}'
+
+sysctlInitContainer:
+  enabled: true
+
+keystore: []
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## In order for a Pod to access Elasticsearch, it needs to have the following label:
+  ## {{ template "uname" . }}-client: "true"
+  ## Example for default configuration to access HTTP port:
+  ## elasticsearch-master-http-client: "true"
+  ## Example for default configuration to access transport port:
+  ## elasticsearch-master-transport-client: "true"
+
+  http:
+    enabled: false
+    ## if explicitNamespacesSelector is not set or set to {}, only client Pods being in the networkPolicy's namespace
+    ## and matching all criteria can reach the DB.
+    ## But sometimes, we want the Pods to be accessible to clients from other namespaces, in this case, we can use this
+    ## parameter to select these namespaces
+    ##
+    # explicitNamespacesSelector:
+    #   # Accept from namespaces with all those different rules (only from whitelisted Pods)
+    #   matchLabels:
+    #     role: frontend
+    #   matchExpressions:
+    #     - {key: role, operator: In, values: [frontend]}
+
+    ## Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
+    ##
+    # additionalRules:
+    #   - podSelector:
+    #       matchLabels:
+    #         role: frontend
+    #   - podSelector:
+    #       matchExpressions:
+    #         - key: role
+    #           operator: In
+    #           values:
+    #             - frontend
+
+  transport:
+    ## Note that all Elasticsearch Pods can talk to themselves using transport port even if enabled.
+    enabled: false
+    # explicitNamespacesSelector:
+    #   matchLabels:
+    #     role: frontend
+    #   matchExpressions:
+    #     - {key: role, operator: In, values: [frontend]}
+    # additionalRules:
+    #   - podSelector:
+    #       matchLabels:
+    #         role: frontend
+    #   - podSelector:
+    #       matchExpressions:
+    #         - key: role
+    #           operator: In
+    #           values:
+    #             - frontend
+
+tests:
+  enabled: true

--- a/overlays/elastic/kustomization.yaml
+++ b/overlays/elastic/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+- elasticsearch/


### PR DESCRIPTION
Add ElasticSearch to the cluster
Requires quite a bit of RAM for each of the PODs
I am still working on the integration with Rucio

But this, at least for me, deployed an ES that I was able to curl against.
Which branch would you like to me to modify to try and get it to contact the ES cluster?
Hermes requires some specific config to push directly to ES that I am still trying to figure out