### PR TITLE
Update elastic settings to match experience from RAL rucio needs

### DIFF
--- a/overlays/dev/Makefile
+++ b/overlays/dev/Makefile
@@ -1,10 +1,12 @@
 SERVER_CHART_VERSION := 32.0.0
 DAEMON_CHART_VERSION := 32.0.2
 UI_CHART_VERSION := 32.0.1
+ELASTIC_VERSION := 0.8.0
 
 helm:
 	helm repo add rucio https://rucio.github.io/helm-charts
-	helm repo update
+	helm repo add elastic https://helm.elastic.co
+	helm repo update rucio elastic
 
 rucio-server: helm
 	helm template usdf rucio/rucio-server --version=${SERVER_CHART_VERSION} --values=rucio/values-rucio-server.yaml > rucio/helm-rucio-server.yaml
@@ -16,6 +18,12 @@ rucio-ui: helm
 	helm template usdf rucio/rucio-ui --version=${UI_CHART_VERSION} --values=rucio/values-rucio-ui.yaml > rucio/helm-rucio-ui.yaml
 
 rucio: rucio-server rucio-daemons rucio-ui
+
+elasticsearch:
+	helm template elasticsearch elastic/eck-elasticsearch --version=${ELASTIC_VERSION} --values=elastic/elasticsearch/values-elasticsearch.yaml > elastic/elasticsearch/helm-elasticsearch.yaml
+	vi elastic/elasticsearch/helm-elasticsearch.yaml -c ":%s/enterprise/basic/g" -c ":wq"
+
+elastic: elasticsearch
 
 get-secrets:
 	mkdir -p rucio/etc/.secrets
@@ -38,16 +46,16 @@ clean-secrets:
 run-dump: 
 	kubectl kustomize .
 
-dump: get-secrets rucio run-dump clean-secrets
+dump: get-secrets rucio elastic run-dump clean-secrets 
 
 run-apply:  
 	kubectl apply -k .
 
-apply: get-secrets rucio run-apply clean-secrets
+apply: get-secrets rucio elastic run-apply clean-secrets 
 
 run-destroy:
 	kubectl delete -k .
 
-destroy: get-secrets rucio run-destroy clean-secrets
+destroy: get-secrets rucio elastic run-destroy clean-secrets 
 
 

--- a/overlays/dev/elastic/elasticsearch/helm-elasticsearch.yaml
+++ b/overlays/dev/elastic/elasticsearch/helm-elasticsearch.yaml
@@ -12,7 +12,17 @@ metadata:
   annotations:
     eck.k8s.elastic.co/license: basic
 spec:
+  updateStrategy:
+    changeBudget:
+      maxSurge: 3
+      maxUnavailable: 1
+  http:
+    tls:
+      selfSignedCertificate:
+        disabled: true
   version: 8.11.0
+  volumeClaimDeletePolicy:
+    DeleteOnScaledownOnly
   nodeSets:
     
     - config:
@@ -27,9 +37,11 @@ spec:
           - name: elasticsearch
             resources:
               limits:
-                memory: 2Gi
+                cpu: 2
+                memory: 5Gi
               requests:
-                memory: 2Gi
+                cpu: 1
+                memory: 3Gi
     - config:
         node.roles:
         - data
@@ -44,6 +56,8 @@ spec:
           - name: elasticsearch
             resources:
               limits:
-                memory: 2Gi
+                cpu: 3
+                memory: 9Gi
               requests:
-                memory: 2Gi
+                cpu: 1
+                memory: 5Gi

--- a/overlays/dev/elastic/elasticsearch/values-elasticsearch.yaml
+++ b/overlays/dev/elastic/elasticsearch/values-elasticsearch.yaml
@@ -61,7 +61,10 @@ transport: {}
 
 # Settings to control how Elasticsearch will be accessed.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
-http: {}
+http:
+  tls:
+    selfSignedCertificate:
+      disabled: true
 # service:
 #   metadata:
 #     labels:
@@ -94,10 +97,10 @@ secureSettings: {}
 
 # Settings for limiting the number of simultaneous changes to an Elasticsearch resource.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-update-strategy.html
-updateStrategy: {}
-# changeBudget:
-#   maxSurge: 3
-#   maxUnavailable: 1
+updateStrategy:
+  changeBudget:
+    maxSurge: 3
+    maxUnavailable: 1
 
 # Controlling of connectivity between remote clusters within the same kubernetes cluster.
 # ref: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-remote-clusters.html
@@ -110,7 +113,7 @@ remoteClusters: {}
 # VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
 # Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion.
 # By default, if not set or empty, the operator sets DeleteOnScaledownAndClusterDeletion.
-volumeClaimDeletePolicy: ""
+volumeClaimDeletePolicy: "DeleteOnScaledownOnly"
 
 # Settings to limit the disruption when pods need to be rescheduled for some reason such as upgrades or routine maintenance.
 # By default, if not set, the operator sets a budget that doesn't allow any pod to be removed in case the cluster is not green or if there is only one node of type `data` or `master`.
@@ -189,11 +192,11 @@ nodeSets:
           # it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
           # Defaults used by the ECK Operator, if not specified, are below
           limits:
-            # cpu: 1
-            memory: 2Gi
+            cpu: 2
+            memory: 5Gi
           requests:
-            # cpu: 1
-            memory: 2Gi
+            cpu: 1
+            memory: 3Gi
 
           # Example increasing both the requests and limits values:
           # limits:
@@ -337,11 +340,11 @@ nodeSets:
           # it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value.
           # Defaults used by the ECK Operator, if not specified, are below
           limits:
-            # cpu: 1
-            memory: 2Gi
+            cpu: 3
+            memory: 9Gi
           requests:
-            # cpu: 1
-            memory: 2Gi
+            cpu: 1
+            memory: 5Gi
 
           # Example increasing both the requests and limits values:
           # limits:


### PR DESCRIPTION
There are a few changes here
Added elastic to the Makefile
There is changing the update strategy so updates will roll out rather then bring a cluster down and then up again
There is the disable of HTTPS - feel free to remove for your cluster if you have CA certs auto generated
The volumeClaimDeletePolicy - set for mine as I use Longhorn for persistent storage,

Unfortunately with the template there is no way to specify the PVC size, and I have had to change that manually
I am currently running 40GB per node - filled to 8GB in a couple days

Of course you can change this in values and then run the make to re-create the helm